### PR TITLE
feat: Refactored code

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ into terraform variables.
 
 For example, if your define the following `action.yaml`:
 ```yaml
-  - name: Shared Info
-    id: project-base
+  - name: My Project
+    id: project
     uses: aplaceformom/terraform-project-base-action@master
     with:
       workspace: dev
-      project: es-example-action
-      owner: techops
-      email: alex.moreno@aplaceformom.com
+      project: my-project
+      owner: myteam
+      email: myteam@example.org
       remote_state_bucket: apfm-terraform-remotestate
       remote_lock_table: terraform-statelock
       shared_state_key: terraform/apfm.tfstate
@@ -28,34 +28,55 @@ For example, if your define the following `action.yaml`:
   - name: Elasticsearch Deploy
     uses: aplaceformom/terraform-elasticsearch-action@master
     with:
-      es_domain: demo-elasticsearch-actions # <--- Domain Name 
-      es_source_ip: 10.0.0.0/8,170.150.57.105/32 # <--- IP Allowed to connect
-      es_source_resource: null 
-      es_instance_type: 'm3.xlarge.elasticsearch'
-      es_instance_count: 2
-      es_vpc: true
       aws_assume_role: arn:aws:iam::${{ steps.project-base.outputs.account_id }}:role/TerraformApply
       aws_external_id: ${{ steps.project-base.outputs.external_id }}
-      destroy: false
 ```
 
-**es_instance_type:** (Valid options)
+### version
+ElasticSearch engine version
+- default: 7.4
 
-```
-[i3.2xlarge.elasticsearch, m5.4xlarge.elasticsearch, i3.4xlarge.elasticsearch, m3.large.elasticsearch, r4.16xlarge.elasticsearch, t2.micro.elasticsearch, m4.large.elasticsearch, d2.2xlarge.elasticsearch, m5.large.elasticsearch, i3.8xlarge.elasticsearch, i3.large.elasticsearch, d2.4xlarge.elasticsearch, t2.small.elasticsearch, c4.2xlarge.elasticsearch, c5.2xlarge.elasticsearch, c4.4xlarge.elasticsearch, d2.8xlarge.elasticsearch, c5.4xlarge.elasticsearch, m3.medium.elasticsearch, c4.8xlarge.elasticsearch, c4.large.elasticsearch, c5.xlarge.elasticsearch, c5.large.elasticsearch, c4.xlarge.elasticsearch, c5.9xlarge.elasticsearch, d2.xlarge.elasticsearch, t2.medium.elasticsearch, c5.18xlarge.elasticsearch, i3.xlarge.elasticsearch, i2.xlarge.elasticsearch, r3.2xlarge.elasticsearch, r4.2xlarge.elasticsearch, m5.xlarge.elasticsearch, m4.10xlarge.elasticsearch, r3.4xlarge.elasticsearch, r5.2xlarge.elasticsearch, m5.12xlarge.elasticsearch, m4.xlarge.elasticsearch, r4.4xlarge.elasticsearch, m5.24xlarge.elasticsearch, m3.xlarge.elasticsearch, i3.16xlarge.elasticsearch, r5.4xlarge.elasticsearch, ultrawarm1.large.elasticsearch, m3.2xlarge.elasticsearch, r3.8xlarge.elasticsearch, r3.large.elasticsearch, r5.xlarge.elasticsearch, m4.2xlarge.elasticsearch, r4.8xlarge.elasticsearch, r4.xlarge.elasticsearch, r4.large.elasticsearch, r5.12xlarge.elasticsearch, m5.2xlarge.elasticsearch, i2.2xlarge.elasticsearch, r3.xlarge.elasticsearch, r5.24xlarge.elasticsearch, r5.large.elasticsearch, m4.4xlarge.elasticsearch]
-```
+### ebs
+Enable ebs storage.
+- default: true
 
-**es_volume_type:** 
+### instance_type
+The ElasticSearch instance type to use. See: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-supported-instance-types.html
+- default: t2.medium.elasticsearch
 
-- standard
-- gp2
-- io1
+### instance_count
+The number of nodes to run in your instance. Note: enabling 3 instances will
+make the cluster multi-availability-zone aware.
+- default: 1
 
-**tags**
+### volume_type
+ElasticSearch Volume type (standard, gp2, io1)
+- default: gp2
+
+### volume_size
+Per instance volume size (in gigs).
+- default: 10
+
+### log_type
+A type of Elasticsearch log. Valid values: INDEX_SLOW_LOGS, SEARCH_SLOW_LOGS, ES_APPLICATION_LOGS
+- default: INDEX_SLOW_LOGS
+
+### public
+Make ElasticSearch accessible publicly (dangerous). If you enable this option
+then the ElasticSearch cluster will be made available on a public IP.  You
+should configured the `allowed_ips` to restrict access to the instance.
+- default: false
+
+### allowed_ips
+A comman seperated list of network maps (in CIDR format) which should be
+granted access to this ElasticSearch instance (only valid if public = true).
+- example: x.x.x.x/32,y.y.y.y/24
+- default: N/A
 
 - More information about the valid options to be used, can be found [here](https://aplaceformom.atlassian.net/wiki/spaces/TECHOPS/pages/1049133728/2020+AWS+Tagging+Standards) 
 
-## Test executed:
+Test executed
+-------------
 
 - Add more nodes to a cluster previously created: 
   - Result: Nodes were added without interrupt service.
@@ -66,8 +87,8 @@ For example, if your define the following `action.yaml`:
 - Downsize nodes:
   - Result: Nodes were downsized without interruption.
 
-
-## URL used to create this action
+References
+----------
 
 - https://www.terraform.io/docs/providers/aws/r/elasticsearch_domain.html
 - https://docs.aws.amazon.com/cli/latest/reference/es/create-elasticsearch-domain.html

--- a/action.yaml
+++ b/action.yaml
@@ -1,111 +1,53 @@
 name: Elasticsearch Deploy
 description: Deploy an AWS Elasctisearch service cluster using Terraform
 inputs:
-  workspace:
-    description: 'Terraform Workspace'
-    required: true
-
-  project:
-    description: 'Project this Service is part of'
-    required: true
-
-  owner:
-    description: 'Project owner/team'
-    required: true
-
-  email:
-    description: 'Project email address'
-    required: true
-
-  repo:
-    description: 'GITHUB Repository'
-    required: true
-
-  budget:
-    description: 'Budget'
-    required: true
-
-  app: 
-    description: 'App Name'
-    required: true
-
-  destroy:
-    description: 'Runs Terraform destroy to destroy existing resources created by this action'
-    required: false
-    default: 'false'
-
-  region:
-    description: 'AWS region to deploy to'
-    required: false
-    default: 'us-west-2'
-
-  es_domain:
-    description: 'AWS Elasticsearch service domain'
-    required: true
-
-  es_version:
+  version:
     description: 'Elasticsearch version number'
-    required: true
     default: '7.4'
 
-  es_instance_type:
+  instance_type:
     description: 'AWS Instance Type to deploy the cluster'
     default: 't2.medium.elasticsearch'
-    required: true
 
-  es_instance_count:
+  instance_count:
     description: 'How many instance will compound this cluster'
     default: '1'
-    required: true
 
-  es_snapshot_hour:
+  snapshot_hour:
     description: 'Hour during which the service takes an automated daily snapshot of the indices in the domain. UTC Time'
     default: '23'
-    required: true
 
-  es_ebs_enabled:
+  ebs:
     description: 'Support EBS Storage'
-    default: 'true'
-    required: true
+    default: true
 
-  es_volume_type:
+  volume_type:
     description: 'Kind of storage to use (standard, gp2, io1)'
     default: 'gp2'
-    required: false
 
-  es_volume_size:
-    description: 'Size of the volume for ES Storage'
+  volume_size:
+    description: 'Size of the volume for ES Storage in gigs'
     default: 10
-    required: false
 
-  es_log_type:
+  log_type:
     description: 'A type of Elasticsearch log. Valid values: INDEX_SLOW_LOGS, SEARCH_SLOW_LOGS, ES_APPLICATION_LOGS'
     default: 'INDEX_SLOW_LOGS'
-    required: true
 
-  es_vpc:
-    description: 'VPC Network mode'
+  public:
+    description: 'Enable public ElasticSearch instance'
     default: false
-    required: true
 
-  es_source_ip:
-    description: 'List of IPs valid to connect to the cluster, separated by commas'
-    default: null
-    required: false
-
-  es_source_role:
-    description: 'List of resources allowed to connect to the cluster, separated by commas'
-    default: null
-    required: false
+  allowed_ips:
+    description: 'List of IPs valid to connect to the cluster, separated by commas when [public only]'
 
 outputs:
-  es_arn:
+  arn:
     description: 'Elasticsearch service ARN'
-  es_endpoint:
+  endpoint:
     description: 'Elasticsearch service endpoint'
-  es_kibana_endpoint:
+  kibana_endpoint:
     description: 'Elasticsearch service Kibana endpoint'
-    
+
 runs:
   using: docker
   image: Dockerfile

--- a/logs.tf
+++ b/logs.tf
@@ -1,0 +1,29 @@
+resource "aws_cloudwatch_log_group" "default" {
+  name = "${var.project_name}-logs"
+  tags = local.tags
+}
+
+resource "aws_cloudwatch_log_resource_policy" "logging" {
+  policy_name     = "${var.project-name}-logging-policy"
+  policy_document = data.aws_iam_policy_document.logging.json
+}
+
+data "aws_iam_policy_document" "logging" {
+  statement {
+
+    principals {
+      type        = "Service"
+      identifiers = ["es.amazonaws.com"]
+    }
+
+    actions = [
+      "logs:PutLogEvents",
+      "logs:PutLogEventsBatch",
+      "logs:CreateLogStream"
+    ]
+
+    resources = [
+      "arn:aws:logs:*"
+    ]
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,91 +1,71 @@
 # Log Management
-
 data "aws_region" "current" {}
-
 data "aws_caller_identity" "current" {}
-
 data "aws_vpc" "selected" {
   id = var.network_vpc_id
 }
 
-resource "aws_cloudwatch_log_group" "es_log_group" {
-  name = "${var.es_domain}-log_group"
-  tags = local.common_tags
+data "aws_subnet" "selected" {
+  count = length(split(",", var.subnet_id_private))
+  id    = element(split(",", var.subnet_id_private), count.index)
 }
 
-# Log policy
-
-data "aws_iam_policy_document" "es_log_resource_policy" {
-  statement {
-
-    principals {
-      type        = "Service"
-      identifiers = ["es.amazonaws.com"]
-    }
-
-    actions = [
-      "logs:PutLogEvents",
-      "logs:PutLogEventsBatch",
-      "logs:CreateLogStream"
-    ]
-
-    resources = [
-      "arn:aws:logs:*"
-    ]
+locals {
+  subnet_ids = element(chunklist(data.aws_subnet.selected[*].id), min(var.instance_count, 3)), 0)
+  tags = {
+    app : var.project_name,
+    env : terraform.workspace,
+    budget : var.budget,
+    repo : var.github_repository
+    project : var.project_name,
+    owner : var.project_owner,
+    email : var.project_email,
+    created_by : "terraform-elasticsearch-action"
   }
 }
 
-resource "aws_cloudwatch_log_resource_policy" "es_log_resource_policy" {
-  policy_name = "${var.es_domain}-es_log_resource_policy"
+# Cluster creation
+resource "aws_elasticsearch_domain" "default" {
+  domain_name           = var.project_name
+  elasticsearch_version = var.version
 
-  policy_document = data.aws_iam_policy_document.es_log_resource_policy.json
-}
+  access_policies = var.public ? data.aws_iam_policy_document.public.json : null
 
-# IAM Policy creation (sourceIP)
-data "aws_iam_policy_document" "es_public_source" {
-  statement {
+  cluster_config {
+    instance_type  = var.instance_type
+    instance_count = var.instance_count
 
-    principals {
-      type        = "AWS"
-      identifiers = ["*"]
-    }
-    actions = [
-      "es:*"
-    ]
-
-    resources = [
-      "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.es_domain}/*"
-    ]
-
-    condition {
-      test     = "IpAddress"
-      variable = "aws:SourceIp"
-
-      values = split(",", var.es_source_ip)
+    zone_awareness_enabled = (var.instance_count < 2 ? false : true)
+    zone_awareness_config {
+      availability_zone_count = (var.instance_count < 3 ? (var.instance_count == 2 ? 2 : null ) : 3)
     }
   }
-}
 
-# IAM Policy creation (VPC)
-data "aws_iam_policy_document" "es_vpc_source" {
-  statement {
-
-    principals {
-      type        = "AWS"
-      identifiers = split(",", var.es_source_role)
-    }
-    actions = [
-      "es:*"
-    ]
-
-    resources = [
-      "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.es_domain}/*"
-    ]
+  snapshot_options {
+    automated_snapshot_start_hour = var.snapshot_hour
   }
+
+  vpc_options {
+    subnet_ids         = var.public ? null : data.aws_subnet.selected[*].id
+    security_group_ids = var.public ? null : [aws_security_group.default.id]
+  }
+
+  ebs_options {
+    ebs_enabled = var.ebs
+    volume_type = var.ebs ? var.volume_type : null
+    volume_size = var.ebs ? var.volume_size : null
+  }
+
+  log_publishing_options {
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.logging.arn
+    log_type                 = "INDEX_SLOW_LOGS"
+  }
+
+  tags = local.tags
 }
 
-resource "aws_security_group" "es_security_group" {
-  name        = "${var.network_vpc_id}-elasticsearch-${var.es_domain}"
+resource "aws_security_group" "default" {
+  name        = "${var.project-name}-elasticsearch"
   description = "Managed by terraform-elasticsearch-action"
   vpc_id      = var.network_vpc_id
 
@@ -93,71 +73,8 @@ resource "aws_security_group" "es_security_group" {
     from_port = 443
     to_port   = 443
     protocol  = "tcp"
-
-    #cidr_blocks = data.aws_vpc.selected.cidr_block
-    cidr_blocks = (var.es_source_ip != null ? [data.aws_vpc.selected.cidr_block] : concat([data.aws_vpc.selected.cidr_block], split(",", var.es_source_ip)))
+    cidr_blocks = var.public ? split(var.allowed_ips) : compact(data.aws_subnet.selected[*].cidr_block)
   }
 
-  tags = local.common_tags
-}
-
-# Cluster creation
-
-resource "aws_elasticsearch_domain" "es_domain" {
-  domain_name           = var.es_domain
-  elasticsearch_version = var.es_version
-
-  cluster_config {
-    instance_type  = var.es_instance_type
-    instance_count = var.es_instance_count
-
-    zone_awareness_enabled = (var.es_instance_count < 2 ? false : true)
-
-    zone_awareness_config {
-      availability_zone_count = (var.es_instance_count < 3 ? (var.es_instance_count == 2 ? 2 : null ) : 3)
-    }
-  }
-
-  snapshot_options {
-    automated_snapshot_start_hour = var.es_snapshot_hour
-  }
-
-  vpc_options {
-
-    subnet_ids = (var.es_vpc == true && var.es_instance_count >= 3 ? split(",", var.network_private_subnets) : (
-      var.es_vpc == true ? [element(split(",", var.network_private_subnets), 0)] : null
-    ))
-    #subnet_ids = [(var.es_vpc == true ? element(split(",", var.network_private_subnets), 0) : null)]
-
-    security_group_ids = (var.es_vpc == true ? [aws_security_group.es_security_group.id] : null)
-  }
-
-  ebs_options {
-    ebs_enabled = var.es_ebs_enabled
-    volume_type = (var.es_ebs_enabled == true ? var.es_volume_type : null)
-    volume_size = (var.es_ebs_enabled == true ? var.es_volume_size : null)
-  }
-
-  #access_policies = (var.es_vpc == true ? data.aws_iam_policy_document.es_vpc_source.json : data.aws_iam_policy_document.es_public_source.json)
-
-  log_publishing_options {
-    cloudwatch_log_group_arn = aws_cloudwatch_log_group.es_log_group.arn
-    log_type                 = "INDEX_SLOW_LOGS"
-  }
-
-  tags = local.common_tags
-}
-
-locals {
-  common_tags = {
-    app : var.app,
-    env : terraform.workspace,
-    budget : var.budget,
-    repo : var.repo,
-    es_domain : var.es_domain,
-    project : var.project_name,
-    owner : var.project_owner,
-    email : var.project_email,
-    created_by : "terraform-elasticsearch-action"
-  }
+  tags = local.tags
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,11 @@
-output "es" {
-    value = {
-        arn = aws_elasticsearch_domain.es_domain.arn
-        endpoint = aws_elasticsearch_domain.es_domain.endpoint
-        kibana_endpoint = aws_elasticsearch_domain.es_domain.kibana_endpoint
-    } 
+output "arn" {
+  value = aws_elasticsearch_domain.es_domain.arn
+}
+
+output "endpoint" {
+  value = aws_elasticsearch_domain.es_domain.endpoint
+}
+
+output "kibana" {
+  value = var.kibana ? aws_elasticsearch_domain.es_domain.kibana_endpoint : ""
 }

--- a/public.tf
+++ b/public.tf
@@ -1,0 +1,19 @@
+data "aws_iam_policy_document" "allowed_ips" {
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    actions = ["es:*"]
+
+    resources = [
+      "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.es_domain}/*"
+    ]
+
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values = split(",", var.allowed_ips)
+    }
+  }
+}


### PR DESCRIPTION
1. remove `es_` prefixes from variables as these aren't necessary
2. Simplify handling of vpc and private subnet list generation
3. Move `var.es_vpc` to `var.public` and move all IAC related to public
   access to public.tf.
4. Move logging IAC to logging.tf
5. Simpify the action to support our _recommended_ use case.
6. Use existing `var.project_*` and `var.github_*` variables whenever
   possible (avoid requiring user inputs).