### PR TITLE
fix: Attach allowed_ips to the security groups

### DIFF
--- a/public.tf
+++ b/public.tf
@@ -1,6 +1,3 @@
-locals {
-  allowed_ips = var.allowed_ips != "" ? split(var.allowed_ips) : []
-}
 data "aws_iam_policy_document" "allowed_ips" {
   statement {
     principals {


### PR DESCRIPTION
Attaching the allowed_ips to the ingress security group to allow
services to contact Kibana.