### PR TITLE
fix: fixup log suffix

### DIFF
--- a/logs.tf
+++ b/logs.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_log_group" "default" {
-  name = "${var.github_project}-logs"
+  name = "${var.github_project}-es-logs"
   tags = local.tags
 }
 


### PR DESCRIPTION
Include the ECS Action Type in the logging suffix to help avoid log-name
collisions