### PR TITLE
fix: security group name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -67,7 +67,6 @@ resource "aws_elasticsearch_domain" "default" {
 }
 
 resource "aws_security_group" "default" {
-  name        = "${var.github_project}-elasticsearch"
   description = "Managed by terraform-elasticsearch-action"
   vpc_id      = var.network_vpc_id
 


### PR DESCRIPTION
Allow the security group name to be randomly generated (unique) and rely
on tagging to track which security group belongs to which resources.